### PR TITLE
minor bug (phones.txt instead of words.txt)

### DIFF
--- a/egs/wsj/s5/utils/lang/extend_lang.sh
+++ b/egs/wsj/s5/utils/lang/extend_lang.sh
@@ -131,7 +131,7 @@ for n in $(seq 0 $ndisambig); do
   sym='#'$n; if ! grep -w -q "$sym" $dir/phones/disambig.txt; then echo "$sym"; fi
 done > $tmpdir/extra_disambig.txt
 highest_number=$(tail -n 1 $srcdir/phones.txt | awk '{print $2}')
-awk -v start=$highest_number '{print $1, NR+start}' <$tmpdir/extra_disambig.txt >>$dir/words.txt
+awk -v start=$highest_number '{print $1, NR+start}' <$tmpdir/extra_disambig.txt >>$dir/phones.txt
 echo "$0: added $(wc -l <$tmpdir/extra_disambig.txt) extra disambiguation symbols to phones.txt"
 
 


### PR DESCRIPTION
as in the object
line 134 is modified, new phone disambiguation symbols in the grammar-fst lexicon update, are added  at the end of phones.txt not words.txt